### PR TITLE
Added client.tg.getChat() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,23 @@ await client.tg.deleteChat(-12345678901234)
 </p>
 </details>
 
+
+##### `client.tg.getChat(args = {})` -> Promise -> Object
+
+
+<details>
+<summary>Expand</summary>
+<p>
+
+This API is provided by tglib, you can use this API to get a chat by username or chat id. This method requires either `username` option, or `chat_id` option.
+
+```js
+const chat1 = await client.tg.getChat({ username: 'chat_username' })
+const chat2 = await client.tg.getChat({ chat_id: '-12345678901234' })
+```
+</p>
+</details>
+
 -----
 
 ### Requirements

--- a/TG.js
+++ b/TG.js
@@ -184,6 +184,28 @@ class TG {
       'remove_from_chat_list': true,
     })
   }
+
+  /*
+   *  Get chat by username or id
+   */
+  async getChat(args = {}) {
+    const { username, chat_id } = args
+    let chat = {}
+    if (username) {
+      chat = await this.client.fetch({
+        '@type': 'searchPublicChat',
+        username,
+      })
+    } else if (chat_id) {
+      chat = await this.client.fetch({
+        '@type': 'getChat',
+        chat_id,
+      })
+    } else {
+      throw new Error('Neither username nor chat_id were specified for method "getChat"')
+    }
+    return chat
+  }
 }
 
 module.exports = TG


### PR DESCRIPTION
You can use this method to get a chat by username or chat id. This method requires either `username` option, or `chat_id` option in args object.